### PR TITLE
statistics backend and basic frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,17 @@ This renders the `index.html` file that will be used to interact with the backen
 
 - `403` if user is not logged in
 
+#### `GET /api/timeblock/stats/:userId` - Get the statistics for a given user, including total hours accepted (as owner) and meeting success rate (hours met / hours accepted)
+
+**Returns**
+
+- An object of all the statistics available for users to see
+
+**Throws**
+
+- `403` if user is not logged in
+- `404` if the userId is not a valid one
+
 #### `PUT /api/timeblock` - Create a new time block.
 
 **Body**

--- a/client/components/Profile/PersonalInfoComponent.vue
+++ b/client/components/Profile/PersonalInfoComponent.vue
@@ -17,8 +17,15 @@
         <p>Bio: {{ user.bio ?? '' }}</p>
       </section>
     </section>
-    <section class="availability">
-      <section class="availabilityHeader">
+    <section class="segment">
+      <section class="segmentHeader">
+        <h3><b>{{ user.firstName }}'s Statistics</b></h3>
+      </section>
+      <p><b>Hours accepted: </b>{{statistics.totalHoursAccepted}}</p>
+      <p><b>Meeting success rate: </b>{{statistics.meetingSuccessRate}}</p>
+    </section>
+    <section class="segment">
+      <section class="segmentHeader">
         <h3><b>Availability</b></h3>
         <button 
           v-if="user._id === $store.state.userId"
@@ -70,11 +77,13 @@ export default {
   data() {
     return {
       user: null,
+      statistics: {},
       availabilities: []
     }
   },
   mounted() {
     this.getUser();
+    this.getStats();
     this.getAvailibilities();
   },
   methods: {
@@ -85,6 +94,14 @@ export default {
         throw new Error(res.error);
       }
       this.user = res.user;
+    },
+    async getStats() {
+      const r = await fetch(`api/timeblock/stats/${this.userId}`);
+      const res = await r.json();
+      if (!r.ok) {
+        throw new Error(res.error);
+      }
+      this.statistics = res.statistics;
     },
     getAvailibilities() {
         const availabilities = [
@@ -106,11 +123,11 @@ export default {
 .flatText {
     color: gray
 }
-.availability {
+.segment {
     border-top: 1px solid black;
 }
 
-.availabilityHeader {
+.segmentHeader {
     display: flex;
     justify-content: space-between;
     align-items: center;

--- a/client/components/Search/UserCardComponent.vue
+++ b/client/components/Search/UserCardComponent.vue
@@ -8,11 +8,6 @@
     <div class="otherInfo">
       <i>Class of {{ user.graduationYear }}</i>
       <p><b>Industry: {{ user.industry !== undefined ? user.industry : "None" }}</b></p>
-      <section class="box">
-        <h3>Statistics</h3>
-        <p><b>Hours accepted: </b>{{statistics.totalHoursAccepted}}</p>
-        <p><b>Meeting success rate: </b>{{statistics.meetingSuccessRate}}</p>
-      </section>
     </div>
   </section>
 </template>
@@ -25,25 +20,6 @@ export default {
             type: Object,
             required: true
         }
-    },
-    data() {
-      return {
-        statistics: {},
-      }
-    },
-    mounted() {
-      console.log(this.user);
-      this.getStats();
-    },
-    methods: {
-      async getStats() {
-        const r = await fetch(`api/timeblock/stats/${this.user._id}`);
-        const res = await r.json();
-        if (!r.ok) {
-          throw new Error(res.error);
-        }
-        this.statistics = res.statistics;
-      }
     }
 }
 </script>
@@ -53,11 +29,6 @@ export default {
     padding: 10px;
     padding-top: 20px;
     margin: 5px;
-}
-
-.box {
-  border: 1px solid gray;
-  padding: 2%;
 }
 
 .name {

--- a/client/components/Search/UserCardComponent.vue
+++ b/client/components/Search/UserCardComponent.vue
@@ -8,6 +8,11 @@
     <div class="otherInfo">
       <i>Class of {{ user.graduationYear }}</i>
       <p><b>Industry: {{ user.industry !== undefined ? user.industry : "None" }}</b></p>
+      <section class="box">
+        <h3>Statistics</h3>
+        <p><b>Hours accepted: </b>{{statistics.totalHoursAccepted}}</p>
+        <p><b>Meeting success rate: </b>{{statistics.meetingSuccessRate}}</p>
+      </section>
     </div>
   </section>
 </template>
@@ -20,6 +25,25 @@ export default {
             type: Object,
             required: true
         }
+    },
+    data() {
+      return {
+        statistics: {},
+      }
+    },
+    mounted() {
+      console.log(this.user);
+      this.getStats();
+    },
+    methods: {
+      async getStats() {
+        const r = await fetch(`api/timeblock/stats/${this.user._id}`);
+        const res = await r.json();
+        if (!r.ok) {
+          throw new Error(res.error);
+        }
+        this.statistics = res.statistics;
+      }
     }
 }
 </script>
@@ -29,6 +53,11 @@ export default {
     padding: 10px;
     padding-top: 20px;
     margin: 5px;
+}
+
+.box {
+  border: 1px solid gray;
+  padding: 2%;
 }
 
 .name {

--- a/server/timeblock/collection.ts
+++ b/server/timeblock/collection.ts
@@ -112,6 +112,27 @@ class TimeBlockCollection {
   }
 
   /**
+   * Get the number of total meetings that the user has accepted
+   * 
+   * @param {string} userId - The id of the user
+   * @return {Promise<Number>} - The number of meetings a user owns and has accepted 
+   */
+   static async findTotalAcceptedByOwner(userId: Types.ObjectId | string): Promise<Number> {
+    return TimeBlockModel.find({owner: userId, accepted: true}).count();
+  }
+
+  /**
+   * Get the number of total meetings that the user has attended (or at least 
+   * has not been reported as not attending)
+   * 
+   * @param {string} userId - The id of the user
+   * @return {Promise<Number>} - The number of meetings a user owns, has accepted, and has attended 
+   */
+  static async findTotalMetByOwner(userId: Types.ObjectId | string): Promise<Number> {
+    return TimeBlockModel.find({owner: userId, accepted: true, met: {$ne: false}}).count();
+  }
+
+  /**
    * Update a time block with the new requester
    *
    * @param {string} timeBlockId - The id of the time block to be updated

--- a/server/timeblock/middleware.ts
+++ b/server/timeblock/middleware.ts
@@ -21,7 +21,7 @@ const isUserGiven = async (req: Request, res: Response, next: NextFunction) => {
 const isValidUserParam = async (req: Request, res: Response, next: NextFunction) => {
   const user = await UserCollection.findOneByUserId(req.params.userId);
 
-  if (user) {
+  if (!user) {
     res.status(404).json({
       error: `User with ID ${req.params.userId} does not exist.`
     });
@@ -37,7 +37,7 @@ const isValidUserParam = async (req: Request, res: Response, next: NextFunction)
 const isValidUserBody = async (req: Request, res: Response, next: NextFunction) => {
   const user = await UserCollection.findOneByUserId(req.body.userId);
 
-  if (user) {
+  if (!user) {
     res.status(404).json({
       error: `User with ID ${req.params.userId} does not exist.`
     });
@@ -52,7 +52,7 @@ const isValidUserBody = async (req: Request, res: Response, next: NextFunction) 
  */
 const isValidInput = async (req: Request, res: Response, next: NextFunction) => {
   const {input} = req.body as {input: boolean};
-  if (input && !input) {
+  if (!input && input) {
     res.status(404).json({error: 'Invalid input value.'});
     return;
   }

--- a/server/timeblock/router.ts
+++ b/server/timeblock/router.ts
@@ -142,6 +142,36 @@ router.get(
 );
 
 /**
+ * Get the statistics for a given user, including total hours accepted (as owner) 
+ * and meeting success rate (hours met / hours accepted)
+ *
+ * @name GET /api/timeblock/stats/:userId
+ *
+ * @return {TimeBlockResponse[]} - An object of all the statistics available for users to see
+ * @throws {403} - If the user is not logged in
+ * @throws {404} - If the userId is not a valid one
+ */
+router.get(
+  '/stats/:userId?',
+  [
+    userValidator.isUserLoggedIn,
+    timeBlockValidator.isValidUserParam
+  ],
+  async (req: Request, res: Response) => {
+    const {userId} = req.params;
+    const totalHoursAccepted = await TimeBlockCollection.findTotalAcceptedByOwner(userId) as number;
+    const totalHoursMet = await TimeBlockCollection.findTotalMetByOwner(userId) as number;
+    res.status(200).json({
+      message: 'totalHoursAccepted and meetingSuccessRate were fetched successfully.',
+      statistics: {
+        totalHoursAccepted: totalHoursAccepted,
+        meetingSuccessRate: `${(totalHoursAccepted) ? totalHoursMet / totalHoursAccepted : 0}`,
+      }
+    });
+  }
+);
+
+/**
  * Create a new time block.
  *
  * @name PUT /api/timeblock


### PR DESCRIPTION
- added route for `/api/timeblock/stats/:userId`, which returns `totalHoursMet` and `meetingSuccessRate` as statistics, along with associated methods in `timeblock/collection.ts`
- edited unrelated bugs with validating users in `timeblock/middleware.ts`
- added frontend view of statistics to user profiles