### PR TITLE
conflicting timeblocks

### DIFF
--- a/server/timeblock/middleware.ts
+++ b/server/timeblock/middleware.ts
@@ -67,7 +67,10 @@ const isBlockNonexistent = async (req: Request, res: Response, next: NextFunctio
   const userId = req.session.userId as string;
   const timeBlocks = await TimeBlockCollection.findAllByUser(userId);
   const start = new Date(req.body.start);
-  const sameStartBlock = timeBlocks.filter(block => block.start == start);
+  console.log(start);
+  timeBlocks.map((block) => console.log(block.start));
+  const sameStartBlock = timeBlocks.filter((block) => (block.start.getTime() == start.getTime()));
+  console.log(sameStartBlock);
 
   if (sameStartBlock.length > 0) {
     res.status(409).json({

--- a/server/timeblock/middleware.ts
+++ b/server/timeblock/middleware.ts
@@ -65,12 +65,9 @@ const isValidInput = async (req: Request, res: Response, next: NextFunction) => 
  */
 const isBlockNonexistent = async (req: Request, res: Response, next: NextFunction) => {
   const userId = req.session.userId as string;
-  const timeBlocks = await TimeBlockCollection.findAllByUser(userId);
+  const timeBlocks = await TimeBlockCollection.findAllByOwner(userId);
   const start = new Date(req.body.start);
-  console.log(start);
-  timeBlocks.map((block) => console.log(block.start));
   const sameStartBlock = timeBlocks.filter((block) => (block.start.getTime() == start.getTime()));
-  console.log(sameStartBlock);
 
   if (sameStartBlock.length > 0) {
     res.status(409).json({

--- a/server/timeblock/router.ts
+++ b/server/timeblock/router.ts
@@ -356,6 +356,12 @@ router.patch(
   async (req: Request, res: Response) => {
     if (req.body.input) {
       const timeBlock = await TimeBlockCollection.updateOneAccepted(req.params.timeBlockId);
+      // deletes any of a requester's unclaimed time blocks with the same start as the accepted block 
+      const requesterTimeBlocks = await TimeBlockCollection.findAllByOwnerUnclaimed(timeBlock.requester._id);
+      const sameTime = requesterTimeBlocks.filter((block) => block.start.getTime() == timeBlock.start.getTime());
+      if (sameTime) {
+        sameTime.map(async (block) => await TimeBlockCollection.deleteOne(block._id));
+      }
       res.status(200).json({
         message: 'The request was accepted successfully.',
         timeBlock: util.constructTimeBlockResponse(timeBlock)


### PR DESCRIPTION
- fixed issue where users could input availabilities at same time
- deletes a requester's unclaimed time block with the same start time as a meeting they've requested if the request was accepted so that users can't have meetings at the same time