### PR TITLE
modifications to calendar display

### DIFF
--- a/client/components/Profile/CalendarComponent.vue
+++ b/client/components/Profile/CalendarComponent.vue
@@ -44,7 +44,7 @@
               </section>
               <section 
                 v-for="block in date"
-                :key="block.start.getHours()"
+                :key="block._id"
                 class="timeBlock"
               >
                 {{ block.start.getHours() % 12 == 0 ?

--- a/client/components/Profile/CalendarComponent.vue
+++ b/client/components/Profile/CalendarComponent.vue
@@ -333,9 +333,7 @@ export default {
                 method: 'PUT',
                 headers: {'Content-Type': 'application/json'},
                 credentials: 'same-origin',
-                body: JSON.stringify({
-                  start: date.toString(),
-                })
+                body: JSON.stringify({start: date.toString()})
             };
 
             try {

--- a/client/components/Profile/PersonalInfoComponent.vue
+++ b/client/components/Profile/PersonalInfoComponent.vue
@@ -13,7 +13,7 @@
           Last Active: {{ user.lastActive }}
         </i>
         <p v-if="(user._id === $store.state.userId)">
-          You <b>{{ $store.state.hasAccess == true ? 'can' : 'can not' }}</b> request meetings with others
+          You <b>{{ $store.state.hasAccess === true ? 'can' : 'can not' }}</b> request meetings with others
         </p>
         <hr/>
         <section class="editInfo"

--- a/client/store.ts
+++ b/client/store.ts
@@ -14,7 +14,7 @@ const store = new Vuex.Store({
     user: null, // logged in user
     userId: null, // User ID of logged in user
     users: [], // All users
-    hasAccess: false,
+    hasAccess: null,
     alerts: {} // global success/error messages encountered during submissions to non-visible forms
   },
   mutations: {


### PR DESCRIPTION
timeblock display:
- if a user has no availabilities, don't show the calendar.
- if a user has no availabilities but they are editing their own calendar, show the calendar.
- if a timeblock as passed, don't show it on the calendar.
- show request button even if user does not have access but styled to look disabled

calendar display:
- cannot click edit if you don't have a meeting link
- past days are grey, current day is blue, future days are white

requesting:
- after clicking request, message directs you to meetings tab

other minor styling/linguistic changes also 👯 