### PR TITLE
return user info in timeblock response

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,18 @@ This renders the `index.html` file that will be used to interact with the backen
 - `404` if either the time block or the user with given ID does not exist
 - `409` if the time block has already passed
 
+#### `PATCH /api/timeblock/request/:timeBlockId/unsend` - Modify a time block by unsending a request to meet
+
+**Returns**
+
+- the updated time block
+
+**Throws**
+
+- `403` if the user is not logged in or is not the requester of the time block
+- `404` if the time block with given ID does not exist
+- `409` if the time block has already passed
+
 #### `PATCH /api/timeblock/accepted/:timeBlockId` - Modify a time block by accepting or rejecting it
 
 **Body**

--- a/server/timeblock/util.ts
+++ b/server/timeblock/util.ts
@@ -1,12 +1,12 @@
 import type {HydratedDocument} from 'mongoose';
-import moment from 'moment';
 import type {TimeBlock, PopulatedTimeBlock} from '../timeblock/model';
+import { User } from '../user/model';
 
 // Update this if you add a property to the TimeBlock type!
 type TimeBlockResponse = {
   _id: string;
-  owner: string;
-  requester: string;
+  owner: User;
+  requester: User;
   start: string;
   accepted: boolean;
   met: boolean;
@@ -34,14 +34,9 @@ const constructTimeBlockResponse = (timeBlock: HydratedDocument<TimeBlock>): Tim
       versionKey: false // Cosmetics; prevents returning of __v property
     })
   };
-  const owner = timeBlockCopy.owner.email;
-  delete timeBlockCopy.owner;
-  const requester = (timeBlockCopy.requester) ? timeBlockCopy.requester.email : null;
   return {
     ...timeBlockCopy,
     _id: timeBlockCopy._id.toString(),
-    owner,
-    requester,
     start: formatDate(timeBlockCopy.start)
   };
 };


### PR DESCRIPTION
- returns all of a user's info in timeblock response so that meetings page doesn't have to fetch each user's info individually
- also retroactively adds `PATCH /api/timeblock/request/:timeBlockId/unsend` API route to unsend requests to README file for documentation