### PR TITLE
add messages to meeting request

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ This renders the `index.html` file that will be used to interact with the backen
 **Body**
 
 - `userId` _{string}_ - The userId of the requester
+- `message` _{string}_ - The message the requester wants to send with the request
 
 **Returns**
 
@@ -148,6 +149,7 @@ This renders the `index.html` file that will be used to interact with the backen
 - `403` if the user is not logged in or is already the owner of the time block
 - `404` if either the time block or the user with given ID does not exist
 - `409` if the time block has already passed
+- `413` if the message is more than 300 characters long
 
 #### `PATCH /api/timeblock/request/:timeBlockId/unsend` - Modify a time block by unsending a request to meet
 

--- a/server/timeblock/collection.ts
+++ b/server/timeblock/collection.ts
@@ -215,11 +215,13 @@ class TimeBlockCollection {
    *
    * @param {string} timeBlockId - The id of the time block to be updated
    * @param {string} requesterId - The userId of the requester
+   * @param {string} message - The message the requester wants to send with the request
    * @return {Promise<HydratedDocument<TimeBlock>>} - The newly updated time block
    */
-  static async updateOneRequest(timeBlockId: Types.ObjectId | string, requesterId: Types.ObjectId | string = null): Promise<HydratedDocument<TimeBlock>> {
+  static async updateOneRequest(timeBlockId: Types.ObjectId | string, requesterId: Types.ObjectId | string = null, message: string = ''): Promise<HydratedDocument<TimeBlock>> {
     const timeBlock = await TimeBlockModel.findOne({_id: timeBlockId});
     timeBlock.requester = requesterId ? requesterId as Types.ObjectId : null;
+    timeBlock.message = message;
     await timeBlock.save();
     return timeBlock.populate('owner requester');
   }

--- a/server/timeblock/middleware.ts
+++ b/server/timeblock/middleware.ts
@@ -48,6 +48,22 @@ const isValidUserBody = async (req: Request, res: Response, next: NextFunction) 
 };
 
 /**
+ * Checks if the message of the request in req.body is valid, i.e. not more than 300 characters
+ */
+ const isValidMessage = (req: Request, res: Response, next: NextFunction) => {
+  const {message} = req.body as {message: string};
+
+  if (message.trim().length > 300) {
+    res.status(413).json({
+      error: 'Message content must be no more than 300 characters.'
+    });
+    return;
+  }
+
+  next();
+};
+
+/**
  * Checks if an input in req.body is valid
  */
 const isValidInput = async (req: Request, res: Response, next: NextFunction) => {
@@ -226,6 +242,7 @@ export {
   isUserGiven,
   isValidUserParam,
   isValidUserBody,
+  isValidMessage,
   isValidInput,
   isBlockNonexistent,
   isBlockExistent,

--- a/server/timeblock/model.ts
+++ b/server/timeblock/model.ts
@@ -12,6 +12,7 @@ export type TimeBlock = {
   _id: Types.ObjectId; // MongoDB assigns each object this ID on creation
   owner: Types.ObjectId;
   requester: Types.ObjectId;
+  message: string;
   start: Date;
   accepted: boolean;
   met: boolean;
@@ -21,6 +22,7 @@ export type PopulatedTimeBlock = {
   _id: Types.ObjectId; // MongoDB assigns each object this ID on creation
   owner: User;
   requester: User;
+  message: string;
   start: Date;
   accepted: boolean;
   met: boolean;
@@ -44,6 +46,11 @@ const TimeBlockSchema = new Schema<TimeBlock>({
     ref: 'User',
     required: false,
     default: null
+  },
+  // The message a user can send with a meeting request
+  message: {
+    type: String,
+    required: true
   },
   // The start time of the 1hr-long time block
   start: {

--- a/server/timeblock/model.ts
+++ b/server/timeblock/model.ts
@@ -50,7 +50,8 @@ const TimeBlockSchema = new Schema<TimeBlock>({
   // The message a user can send with a meeting request
   message: {
     type: String,
-    required: true
+    required: true,
+    default: ''
   },
   // The start time of the 1hr-long time block
   start: {

--- a/server/timeblock/router.ts
+++ b/server/timeblock/router.ts
@@ -283,11 +283,13 @@ router.delete(
  * @name PATCH /api/timeblock/request/:id
  *
  * @param {string} userId - the userId of the requester
+ * @param {string} message - the message the requester wants to send with the request
  * @return {TimeBlockResponse} - the updated time block
  * @throws {400} - If the user is not given
  * @throws {403} - if the user is not logged in or is already the owner of the time block
  * @throws {404} - If either the time block or the user with given ID does not exist
  * @throws {409} - If the time block has already passed
+ * @throws {413} - If the message is more than 300 characters long
  */
 router.patch(
   '/request/:timeBlockId?',
@@ -295,12 +297,13 @@ router.patch(
     userValidator.isUserLoggedIn,
     timeBlockValidator.isUserGiven,
     timeBlockValidator.isValidUserBody,
+    timeBlockValidator.isValidMessage,
     timeBlockValidator.isBlockExistent,
     timeBlockValidator.isBlockInFuture,
     timeBlockValidator.isBlockNotOwner
   ],
   async (req: Request, res: Response) => {
-    const timeBlock = await TimeBlockCollection.updateOneRequest(req.params.timeBlockId, req.body.userId);
+    const timeBlock = await TimeBlockCollection.updateOneRequest(req.params.timeBlockId, req.body.userId, req.body.message.trim());
     res.status(200).json({
       message: 'Your time block was updated successfully.',
       timeBlock: util.constructTimeBlockResponse(timeBlock)
@@ -327,7 +330,7 @@ router.patch(
     timeBlockValidator.isBlockRequester,
   ],
   async (req: Request, res: Response) => {
-    const timeBlock = await TimeBlockCollection.updateOneRequest(req.params.timeBlockId, null);
+    const timeBlock = await TimeBlockCollection.updateOneRequest(req.params.timeBlockId, null, '');
     res.status(200).json({
       message: 'Your time block was updated successfully.',
       timeBlock: util.constructTimeBlockResponse(timeBlock)
@@ -367,8 +370,8 @@ router.patch(
         timeBlock: util.constructTimeBlockResponse(timeBlock)
       });
     } else {
-      // Keep accepted false, change claimed to false and requester to null
-      const timeBlock = await TimeBlockCollection.updateOneRequest(req.params.timeBlockId, null);
+      // reset time block to be as if the request was unsent
+      const timeBlock = await TimeBlockCollection.updateOneRequest(req.params.timeBlockId, null, '');
       res.status(200).json({
         message: 'The request was rejected successfully.',
         timeBlock: util.constructTimeBlockResponse(timeBlock)

--- a/server/timeblock/util.ts
+++ b/server/timeblock/util.ts
@@ -7,6 +7,7 @@ type TimeBlockResponse = {
   _id: string;
   owner: User;
   requester: User;
+  message: string;
   start: string;
   accepted: boolean;
   met: boolean;


### PR DESCRIPTION
- add `message` as field to model
- return `message` in timeblock response
- update collection method for sending request to include message
- update meeting request route to include message body and check that the message is <= 300 characters (can we get frontend validation for this in the form of an input box that shows an error the second a user types more than 300 char?)
- clear message upon unsending or rejecting a request
- update README file with changes