### PR TITLE
cancel meetings

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ This renders the `index.html` file that will be used to interact with the backen
 
 **Returns**
 
-- A list of all the time blocks for the user to mark as met, sorted in descending order by start
+- A list of all the time blocks that are unclaimed for the user, sorted in descending order by start
 
 **Throws**
 
@@ -175,6 +175,18 @@ This renders the `index.html` file that will be used to interact with the backen
 
 - `403` if the user is not logged in or is not the owner of the time block
 - `404` if either the time block with given ID does not exist or the input is not valid
+
+#### `PATCH /api/timeblock/cancel/:timeBlockId` - Modify a time block by canceling a meeting
+
+**Returns**
+
+- the updated time block
+
+**Throws**
+
+- `403` if the user is not logged in or user is not owner or requester
+- `404` if the time block with given ID does not exist
+- `409` if the time block is not an accepted meeting
 
 #### `PATCH /api/timeblock/met/:timeBlockId` - Modify a time block by marking a meeting as met or not
 

--- a/client/components/Meeting/MeetingPage.vue
+++ b/client/components/Meeting/MeetingPage.vue
@@ -102,7 +102,7 @@
         },
       async getPastMeetings() {
           try {
-            const r = await fetch('/api/timeblock/checkoccurred', {
+            const r = await fetch('/api/timeblock/met/check', {
               method: 'GET', 
               headers: {'Content-Type': 'application/json'}
             });

--- a/client/store.ts
+++ b/client/store.ts
@@ -52,7 +52,7 @@ const store = new Vuex.Store({
       /**
        * Request the server for the currently available freets.
        */
-      const url = state.filter=='Past Meetings' ? `/api/timeblock/checkoccurred` : '/api/timeblock';
+      const url = state.filter=='Past Meetings' ? `/api/timeblock/met/check` : '/api/timeblock';
       const res = await fetch(url).then(async r => r.json());
       state.timeblocks = res;
     },

--- a/server/timeblock/collection.ts
+++ b/server/timeblock/collection.ts
@@ -121,7 +121,7 @@ class TimeBlockCollection {
   }
 
   /**
-   * Get the number of total meetings that the user has accepted including cancellations
+   * Get the number of total meetings that the user has accepted not including cancellations
    * 
    * @param {string} userId - The id of the user
    * @param {Date} startAfter - The date after which to count timeblocks
@@ -129,9 +129,9 @@ class TimeBlockCollection {
    */
    static async findTotalAcceptedByOwner(userId: Types.ObjectId | string, startAfter: Date = null): Promise<Number> {
     if (startAfter) {
-      return TimeBlockModel.find({owner: userId, accepted: true, start: {$gte: startAfter}}).count();
+      return TimeBlockModel.find({owner: userId, accepted: true, status: {$ne: 'CANCELED'}, start: {$gte: startAfter}}).count();
     } else {
-      return TimeBlockModel.find({owner: userId, accepted: true}).count();
+      return TimeBlockModel.find({owner: userId, accepted: true, status: {$ne: 'CANCELED'}}).count();
     }
   }
 

--- a/server/timeblock/collection.ts
+++ b/server/timeblock/collection.ts
@@ -72,7 +72,7 @@ class TimeBlockCollection {
    static async findAllByUserOccurred(userId: Types.ObjectId | string): Promise<Array<HydratedDocument<TimeBlock>>> {
     // Retrieves time blocks and sorts them from latest to earliest time
     const now = new Date();
-    return TimeBlockModel.find({$or: [{owner: userId}, {requester: userId}],start: {$lte: now}, accepted: true, status: null}).sort({start: -1}).populate('owner requester');
+    return TimeBlockModel.find({$or: [{owner: userId}, {requester: userId}],start: {$lte: now}, accepted: true, status: 'UNOCCURRED'}).sort({start: -1}).populate('owner requester');
   }
 
   /**

--- a/server/timeblock/collection.ts
+++ b/server/timeblock/collection.ts
@@ -40,14 +40,14 @@ class TimeBlockCollection {
 
   /**
    * Get all the time blocks in the database with a given user as owner
-   * in order of most to least recent start time
+   * in order of most to least recent start time, uncanceled
    *
    * @param {string} ownerId - The id of the owner
    * @return {Promise<HydratedDocument<TimeBlock>[]>} - An array of all of the time blocks for a given owner
    */
   static async findAllByOwner(ownerId: Types.ObjectId | string): Promise<Array<HydratedDocument<TimeBlock>>> {
     // Retrieves time blocks and sorts them from latest to earliest time
-    return TimeBlockModel.find({owner: ownerId}).sort({start: -1}).populate('owner requester');
+    return TimeBlockModel.find({owner: ownerId, status: {$ne: 'CANCELED'}}).sort({start: -1}).populate('owner requester');
   }
 
   /**
@@ -64,38 +64,28 @@ class TimeBlockCollection {
 
   /**
    * Get all the time blocks in the database with a given user as owner or requester that's passed
-   * in order of most to least recent start time
+   * in order of most to least recent start time, not including canceled ones
    *
    * @param {string} userId - The id of the user
-   * @param {boolean} getUnmarked - Whether we want only unmarked past meetings or all
    * @return {Promise<HydratedDocument<TimeBlock>[]>} - An array of all of the time blocks for a given owner
    */
-   static async findAllByUserOccurred(userId: Types.ObjectId | string, getUnmarked: boolean): Promise<Array<HydratedDocument<TimeBlock>>> {
+   static async findAllByUserOccurred(userId: Types.ObjectId | string): Promise<Array<HydratedDocument<TimeBlock>>> {
     // Retrieves time blocks and sorts them from latest to earliest time
     const now = new Date();
-    if (getUnmarked) {
-      return TimeBlockModel.find({$or: [{owner: userId}, {requester: userId}],start: {$lte: now}, accepted: true, met: null}).sort({start: -1}).populate('owner requester');
-    } else {
-      return TimeBlockModel.find({$or: [{owner: userId}, {requester: userId}],start: {$lte: now}, accepted: true}).sort({start: -1}).populate('owner requester');
-    }
+    return TimeBlockModel.find({$or: [{owner: userId}, {requester: userId}],start: {$lte: now}, accepted: true, status: null}).sort({start: -1}).populate('owner requester');
   }
 
   /**
    * Get all the time blocks in the database with a given user as owner or requester that's passed
-   * in order of most to least recent start time
+   * in order of most to least recent start time, not including cancellations
    *
    * @param {string} userId - The id of the user
-   * @param {boolean} userOwner - Whether we want time blocks that user owns or all
    * @return {Promise<HydratedDocument<TimeBlock>[]>} - An array of all of the time blocks for a given owner
    */
-   static async findAllByUserAccepted(userId: Types.ObjectId | string, userOwner: boolean): Promise<Array<HydratedDocument<TimeBlock>>> {
+   static async findAllByUserAccepted(userId: Types.ObjectId | string): Promise<Array<HydratedDocument<TimeBlock>>> {
     // Retrieves time blocks and sorts them from latest to earliest time
     const now = new Date();
-    if (userOwner) {
-      return TimeBlockModel.find({owner: userId, start: {$gte: now}, accepted: true, met: null}).sort({start: -1}).populate('owner requester');
-    } else {
-      return TimeBlockModel.find({$or: [{owner: userId}, {requester: userId}],start: {$gte: now}, accepted: true}).sort({start: -1}).populate('owner requester');
-    }
+    return TimeBlockModel.find({$or: [{owner: userId}, {requester: userId}],start: {$gte: now}, accepted: true, status: {$ne: 'CANCELED'}}).sort({start: -1}).populate('owner requester');
   }
 
   /**
@@ -131,7 +121,7 @@ class TimeBlockCollection {
   }
 
   /**
-   * Get the number of total meetings that the user has accepted
+   * Get the number of total meetings that the user has accepted including cancellations
    * 
    * @param {string} userId - The id of the user
    * @param {Date} startAfter - The date after which to count timeblocks
@@ -153,7 +143,7 @@ class TimeBlockCollection {
    * @return {Promise<Number>} - The number of meetings a user owns, has accepted, and has attended 
    */
   static async findTotalMetByOwner(userId: Types.ObjectId | string): Promise<Number> {
-    return TimeBlockModel.find({owner: userId, accepted: true, met: {$ne: false}}).count();
+    return TimeBlockModel.find({owner: userId, accepted: true, status: {$ne: ['CANCELED', 'REQUESTER_MET']}}).count();
   }
 
   /**
@@ -163,7 +153,7 @@ class TimeBlockCollection {
    * @return {Promise<Boolean>} - The number of meetings a user owns, has accepted, and has attended 
    */
   static async findAccessStatus(userId: Types.ObjectId | string): Promise<Boolean> {
-    const userBlocks = await TimeBlockModel.find({owner: userId}).sort({start: -1}).populate('owner requester');
+    const userBlocks = await TimeBlockModel.find({owner: userId, status: {$ne: 'CANCELED'}}).sort({start: -1}).populate('owner requester');
     const today = new Date();
     const rangeEnd = new Date();
     rangeEnd.setHours(0, 0, 0, 0);
@@ -206,7 +196,7 @@ class TimeBlockCollection {
    */
    static async findTotalUniqueMetByOwner(ownerId: Types.ObjectId | string): Promise<Number> {
     const now = new Date();
-    const distinct = await TimeBlockModel.find({owner: ownerId, accepted: true, start: {$lte: now}, met: {$ne: false}}).distinct('requester');
+    const distinct = await TimeBlockModel.find({owner: ownerId, accepted: true, start: {$lte: now}, status: {$ne: ['CANCELED', 'REQUESTER_MET']}}).distinct('requester');
     return distinct.length;
   }
 
@@ -241,14 +231,36 @@ class TimeBlockCollection {
    * Update a time block with met
    *
    * @param {string} timeBlockId - The id of the time block to be updated
+   * @param {string} responderId - The id of the responder
    * @param {boolean} met - Whether the meeting should be marked as met or not
    * @return {Promise<HydratedDocument<TimeBlock>>} - The newly updated time block
    */
-     static async updateOneMet(timeBlockId: Types.ObjectId | string, met: boolean): Promise<HydratedDocument<TimeBlock>> {
-        const timeBlock = await TimeBlockModel.findOne({_id: timeBlockId});
-        timeBlock.met = met;
-        await timeBlock.save();
-        return timeBlock.populate('owner requester');
+  static async updateOneMet(timeBlockId: Types.ObjectId | string, responderId: Types.ObjectId | string, met: boolean): Promise<HydratedDocument<TimeBlock>> {
+    const timeBlock = await TimeBlockModel.findOne({_id: timeBlockId});
+    if (met) {
+      timeBlock.status = 'MET';
+    }
+    else if (responderId === timeBlock.owner._id) {
+      timeBlock.status = 'OWNER_MET';
+    }
+    else if (responderId === timeBlock.requester._id) {
+      timeBlock.status = 'REQUESTER_MET';
+    }
+    await timeBlock.save();
+    return timeBlock.populate('owner requester');
+  }
+
+  /**
+   * Update a time block with cancel
+   *
+   * @param {string} timeBlockId - The id of the time block to be updated
+   * @return {Promise<HydratedDocument<TimeBlock>>} - The newly updated time block
+   */
+   static async updateOneCancel(timeBlockId: Types.ObjectId | string): Promise<HydratedDocument<TimeBlock>> {
+    const timeBlock = await TimeBlockModel.findOne({_id: timeBlockId});
+    timeBlock.status = 'CANCELED';
+    await timeBlock.save();
+    return timeBlock.populate('owner requester');
   }
 
   /**

--- a/server/timeblock/collection.ts
+++ b/server/timeblock/collection.ts
@@ -72,7 +72,7 @@ class TimeBlockCollection {
    static async findAllByUserOccurred(userId: Types.ObjectId | string): Promise<Array<HydratedDocument<TimeBlock>>> {
     // Retrieves time blocks and sorts them from latest to earliest time
     const now = new Date();
-    return TimeBlockModel.find({$or: [{owner: userId}, {requester: userId}],start: {$lte: now}, accepted: true, status: 'UNOCCURRED'}).sort({start: -1}).populate('owner requester');
+    return TimeBlockModel.find({$or: [{owner: userId}, {requester: userId}],start: {$lte: now}, accepted: true, status: 'NO_RESPONSE'}).sort({start: -1}).populate('owner requester');
   }
 
   /**

--- a/server/timeblock/model.ts
+++ b/server/timeblock/model.ts
@@ -60,8 +60,8 @@ const TimeBlockSchema = new Schema<TimeBlock>({
   status: {
     type: String,
     required: false,
-    enum: ['MET', 'REQUESTER_MET', 'OWNER_MET', 'CANCELED'],
-    default: null
+    enum: ['UNOCCURRED', 'MET', 'REQUESTER_MET', 'OWNER_MET', 'CANCELED'],
+    default: 'UNOCCURRED'
   }
 });
 

--- a/server/timeblock/model.ts
+++ b/server/timeblock/model.ts
@@ -60,8 +60,8 @@ const TimeBlockSchema = new Schema<TimeBlock>({
   status: {
     type: String,
     required: false,
-    enum: ['UNOCCURRED', 'MET', 'REQUESTER_MET', 'OWNER_MET', 'CANCELED'],
-    default: 'UNOCCURRED'
+    enum: ['NO_RESPONSE', 'MET', 'REQUESTER_MET', 'OWNER_MET', 'CANCELED'],
+    default: 'NO_RESPONSE'
   }
 });
 

--- a/server/timeblock/model.ts
+++ b/server/timeblock/model.ts
@@ -60,7 +60,7 @@ const TimeBlockSchema = new Schema<TimeBlock>({
   status: {
     type: String,
     required: false,
-    enum: ['MET', 'REQUESTER_MET', 'OWNER_MET', 'CANCELLED'],
+    enum: ['MET', 'REQUESTER_MET', 'OWNER_MET', 'CANCELED'],
     default: null
   }
 });

--- a/server/timeblock/model.ts
+++ b/server/timeblock/model.ts
@@ -14,7 +14,7 @@ export type TimeBlock = {
   requester: Types.ObjectId;
   start: Date;
   accepted: boolean;
-  met: boolean;
+  status: string; // 
 };
 
 export type PopulatedTimeBlock = {
@@ -23,7 +23,7 @@ export type PopulatedTimeBlock = {
   requester: User;
   start: Date;
   accepted: boolean;
-  met: boolean;
+  status: string;
 };
 
 // Mongoose schema definition for interfacing with a MongoDB table
@@ -56,10 +56,11 @@ const TimeBlockSchema = new Schema<TimeBlock>({
     required: false,
     default: false
   },
-  // Whether the accepted meeting has actually met
-  met: {
-    type: Boolean,
+  // The status of the meeting
+  status: {
+    type: String,
     required: false,
+    enum: ['MET', 'REQUESTER_MET', 'OWNER_MET', 'CANCELLED'],
     default: null
   }
 });

--- a/server/timeblock/router.ts
+++ b/server/timeblock/router.ts
@@ -46,7 +46,7 @@ router.get(
   ],
   async (req: Request, res: Response) => {
     const userId = (req.session.userId as string) ?? '';
-    const allTimeBlocks = await TimeBlockCollection.findAllByUserAccepted(userId, false);
+    const allTimeBlocks = await TimeBlockCollection.findAllByUserAccepted(userId);
     const response = allTimeBlocks.map(util.constructTimeBlockResponse);
     res.status(200).json(response);
   }
@@ -73,28 +73,6 @@ router.get(
 );
 
 /**
- * Get all the meetings a user has had
- *
- * @name GET /api/timeblock/checkoccurred
- *
- * @return {TimeBlockResponse[]} - A list of all the meetings a user has had,
- *                                sorting in descending order by start
- * @throws {403} - If the user is not logged in
- */
-router.get(
-  '/checkoccurred',
-  [
-    userValidator.isUserLoggedIn
-  ],
-  async (req: Request, res: Response) => {
-    const userId = (req.session.userId as string) ?? '';
-    const occurredTimeBlocks = await TimeBlockCollection.findAllByUserOccurred(userId, false);
-    const response = occurredTimeBlocks.map(util.constructTimeBlockResponse);
-    res.status(200).json(response);
-  }
-);
-
-/**
  * Get all the time blocks that a user needs to mark as met/not
  *
  * @name GET /api/timeblock/met/check
@@ -110,7 +88,7 @@ router.get(
     ],
     async (req: Request, res: Response) => {
       const userId = (req.session.userId as string) ?? '';
-      const unMarkedTimeBlocks = await TimeBlockCollection.findAllByUserOccurred(userId, true);
+      const unMarkedTimeBlocks = await TimeBlockCollection.findAllByUserOccurred(userId);
       const response = unMarkedTimeBlocks.map(util.constructTimeBlockResponse);
       res.status(200).json(response);
     }
@@ -121,8 +99,8 @@ router.get(
  *
  * @name GET /api/timeblock/unclaimed/:userId
  *
- * @return {TimeBlockResponse[]} - A list of all the time blocks for the user 
- *                      to mark as met, sorted in descending order by start
+ * @return {TimeBlockResponse[]} - A list of all the time blocks that are unclaimed
+ *                          for the user, sorted in descending order by start
  * @throws {403} - If the user is not logged in
  * @throws {404} - If the userId is not a valid one
  */
@@ -378,6 +356,33 @@ router.patch(
 );
 
 /**
+ * Modify a time block by canceling a meeting
+ *
+ * @name PATCH /api/timeblock/cancel/:id
+ *
+ * @return {TimeBlockResponse} - the updated time block
+ * @throws {403} - If the user is not logged in or user is not owner or requester
+ * @throws {404} - If the time block with given ID does not exist
+ * @throws {409} - If the time block is not an accepted meeting
+ */
+ router.patch(
+  '/cancel/:timeBlockId?',
+  [
+    userValidator.isUserLoggedIn,
+    timeBlockValidator.isBlockExistent,
+    timeBlockValidator.isBlockAccepted,
+    timeBlockValidator.isBlockOwnerOrRequester,
+  ],
+  async (req: Request, res: Response) => {
+    const timeBlock = await TimeBlockCollection.updateOneCancel(req.params.timeBlockId);
+    res.status(200).json({
+      message: 'Your meeting status was canceled successfully.',
+      timeBlock: util.constructTimeBlockResponse(timeBlock),
+    });
+  }
+);
+
+/**
  * Modify a time block by marking a meeting as met or not
  *
  * @name PATCH /api/timeblock/met/:id
@@ -399,7 +404,7 @@ router.patch(
       timeBlockValidator.isValidInput,
     ],
     async (req: Request, res: Response) => {
-      const timeBlock = await TimeBlockCollection.updateOneMet(req.params.timeBlockId, req.body.input);
+      const timeBlock = await TimeBlockCollection.updateOneMet(req.params.timeBlockId, req.session.userId, req.body.input);
       res.status(200).json({
         message: 'Your meeting status was updated successfully.',
         timeBlock: util.constructTimeBlockResponse(timeBlock),

--- a/server/timeblock/util.ts
+++ b/server/timeblock/util.ts
@@ -9,7 +9,7 @@ type TimeBlockResponse = {
   requester: User;
   start: string;
   accepted: boolean;
-  met: boolean;
+  status: string;
 };
 
 /**


### PR DESCRIPTION
- change model to use string enums for status of meeting (`NO_RESPONSE,CANCELED,OWNER_MET,REQUESTER_MET,MET`) instead of `met`/`requesterMet`/`ownerMet`/`canceled`
- add `/timeblock/cancel/:timeBlockId` to cancel a meeting
- update statistics to fit new cancellation feature