### PR TITLE
add timeblock availabilities in chunks

### DIFF
--- a/client/components/Profile/CalendarComponent.vue
+++ b/client/components/Profile/CalendarComponent.vue
@@ -50,7 +50,8 @@
                 {{ block.start.getHours() % 12 == 0 ?
                   12 :
                   block.start.getHours() % 12
-                }}{{ block.start.getHours() < 12 ? 'am' : 'pm' }}
+                }}:{{ block.start.getMinutes() == 0 ? '00' : block.start.getMinutes() }}
+                {{ block.start.getHours() < 12 ? 'am' : 'pm' }}
                 <div class="row">
                   <section class="column" v-if="userId !== $store.state.userId">
                     <button 

--- a/server/timeblock/collection.ts
+++ b/server/timeblock/collection.ts
@@ -89,8 +89,8 @@ class TimeBlockCollection {
    static async findAllByUserAccepted(userId: Types.ObjectId | string): Promise<Array<HydratedDocument<TimeBlock>>> {
     // Retrieves time blocks and sorts them from latest to earliest time
     const now = new Date();
-    const uncanceled = await TimeBlockModel.find({$or: [{owner: userId}, {requester: userId}], start: {$gte: now}, accepted: true, status: 'NO_RESPONSE'}).sort({start: -1}).populate('owner requester');
-    const canceled = await TimeBlockModel.find({$or: [{owner: userId}, {requester: userId}], start: {$gte: now}, accepted: true, status: 'CANCELED'}).sort({start: -1}).populate('owner requester');
+    const uncanceled = await TimeBlockModel.find({$or: [{owner: userId}, {requester: userId}], start: {$gte: now}, accepted: true, status: 'NO_RESPONSE'}).sort({start: 1}).populate('owner requester');
+    const canceled = await TimeBlockModel.find({$or: [{owner: userId}, {requester: userId}], start: {$gte: now}, accepted: true, status: 'CANCELED'}).sort({start: 1}).populate('owner requester');
     return uncanceled.concat(canceled);
   }
 

--- a/server/timeblock/collection.ts
+++ b/server/timeblock/collection.ts
@@ -15,14 +15,13 @@ class TimeBlockCollection {
    * Add a time block to the collection
    *
    * @param {string} ownerId - The id of the owner of the time block
-   * @param {string} start - The start time of the time block
+   * @param {Date} start - The start time of the time block
    * @return {Promise<HydratedDocument<TimeBlock>>} - The newly created tim eblock
    */
-  static async addOne(ownerId: Types.ObjectId | string, start: string): Promise<HydratedDocument<TimeBlock>> {
-    const time = new Date(start);
+  static async addOne(ownerId: Types.ObjectId | string, start: Date): Promise<HydratedDocument<TimeBlock>> {
     const timeBlock = new TimeBlockModel({
       owner: ownerId,
-      start: time
+      start: start
     });
     await timeBlock.save(); // Saves time block to MongoDB
     return timeBlock.populate('owner');

--- a/server/timeblock/middleware.ts
+++ b/server/timeblock/middleware.ts
@@ -3,6 +3,19 @@ import TimeBlockCollection from '../timeblock/collection';
 import UserCollection from '../user/collection';
 
 /**
+ * Checks if an end time is given in req.body
+ */
+const isEndGiven = async (req: Request, res: Response, next: NextFunction) => {
+  const {end} = req.body as {end: string};
+  if (!end) {
+    res.status(400).json({error: 'Missing end time.'});
+    return;
+  }
+
+  next();
+};
+
+/**
  * Checks if a userId is given in req.body
  */
 const isUserGiven = async (req: Request, res: Response, next: NextFunction) => {
@@ -239,6 +252,7 @@ const isBlockInNextFour = async (req: Request, res: Response, next: NextFunction
 };
 
 export {
+  isEndGiven,
   isUserGiven,
   isValidUserParam,
   isValidUserBody,

--- a/server/timeblock/router.ts
+++ b/server/timeblock/router.ts
@@ -231,6 +231,7 @@ router.get(
  * @param {string} start - The start time of the time block
  * @param {string} end - The end time of the time block
  * @return {TimeBlockResponse[]} - The created time block(s)
+ * @throws {400} - If end time is not given
  * @throws {403} - If the user is not logged in
  * @throws {409} - If the user already has a time block with the given start time 
  *                or if the start time has already passed
@@ -239,6 +240,7 @@ router.put(
   '/',
   [
     userValidator.isUserLoggedIn,
+    timeBlockValidator.isEndGiven,
     timeBlockValidator.isBlockNonexistent,
     timeBlockValidator.isBlockInNextFour
   ],

--- a/server/timeblock/router.ts
+++ b/server/timeblock/router.ts
@@ -189,7 +189,7 @@ router.get(
  *
  * @name GET /api/timeblock/stats/:userId
  *
- * @return {TimeBlockResponse[]} - An object of all the statistics available for users to see
+ * @return {Object} - An object of all the statistics available for users to see
  * @throws {403} - If the user is not logged in
  * @throws {404} - If the userId is not a valid one
  */
@@ -229,7 +229,8 @@ router.get(
  * @name PUT /api/timeblock
  *
  * @param {string} start - The start time of the time block
- * @return {TimeBlockResponse} - The created time block
+ * @param {string} end - The end time of the time block
+ * @return {TimeBlockResponse[]} - The created time block(s)
  * @throws {403} - If the user is not logged in
  * @throws {409} - If the user already has a time block with the given start time 
  *                or if the start time has already passed
@@ -243,12 +244,16 @@ router.put(
   ],
   async (req: Request, res: Response) => {
     const userId = (req.session.userId as string) ?? ''; // Will not be an empty string since its validated in isUserLoggedIn
-    const timeBlock = await TimeBlockCollection.addOne(userId, req.body.start);
-
-    res.status(201).json({
-      message: 'Your time block was created successfully.',
-      timeBlock: util.constructTimeBlockResponse(timeBlock)
-    });
+    var start = new Date(req.body.start);
+    const end = new Date(req.body.end);
+    const created = [];
+    while (start < end) {
+      const timeBlock = await TimeBlockCollection.addOne(userId, start);
+      created.push(timeBlock);
+      start = new Date(start.getTime() + 1000*60*30); //adds half an hour to start
+    }
+    const response = created.map(util.constructTimeBlockResponse);
+    res.status(200).json(response);
   }
 );
 


### PR DESCRIPTION
- update `PUT /` request for a timeblock to require an `end` time in `req.body`
- update `CalendarComponent.vue` to include minute times
- unrelated: display upcoming meetings most -> least recent (instead of other way around)